### PR TITLE
Fix the problem that statsmon node always exit

### DIFF
--- a/with-netstats/eth-netstats/Dockerfile
+++ b/with-netstats/eth-netstats/Dockerfile
@@ -1,4 +1,4 @@
-FROM iojs
+FROM node:7
 
 RUN git clone https://github.com/cubedro/eth-netstats
 RUN cd /eth-netstats && npm install


### PR DESCRIPTION
When using with netstats (for example: docker-compose scale bootstrap=1 miner=2 eth=3 statsmon=1) ,the statsmon node always exit. 

Use "docker-compose logs" to check ,  the statsmon node shows error message as following:

statsmon     | /eth-netstats/node_modules/primus/index.js:177
statsmon     |     const sandbox = Object.keys(global).reduce((acc, key) => {
statsmon     |                                                         ^
statsmon     | 
statsmon     | SyntaxError: missing ) after argument list
statsmon     |     at exports.runInThisContext (vm.js:53:16)
statsmon     |     at Module._compile (module.js:413:25)
statsmon     |     at Object.Module._extensions..js (module.js:448:10)
statsmon     |     at Module.load (module.js:355:32)
statsmon     |     at Function.Module._load (module.js:310:12)
statsmon     |     at Module.require (module.js:365:17)
statsmon     |     at require (module.js:384:17)
statsmon     |     at Object.<anonymous> (/eth-netstats/app.js:44:14)
statsmon     |     at Module._compile (module.js:430:26)
statsmon     |     at Object.Module._extensions..js (module.js:448:10)
statsmon     | 
statsmon     | npm info eth-netstats@0.0.9 Failed to exec start script
statsmon     | npm ERR! Linux 3.13.0-107-generic
statsmon     | npm ERR! argv "/usr/local/bin/iojs" "/usr/local/bin/npm" "start"
statsmon     | npm ERR! node v3.3.0
statsmon     | npm ERR! npm  v2.13.3

It seems to be the same issue like this:
 https://github.com/Capgemini-AIE/ethereum-docker/issues/17 

After modifying base image (replace "FROM iojs" with "FROM node:7") ,the statsmon node could work normally.